### PR TITLE
Fix messaging notification routing errors and lease agreement buttons

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -73,8 +73,8 @@ class MessagesController < ApplicationController
 
     respond_to do |format|
       if @message.save
-        # Check if bot should respond
-        bot_response = check_for_bot_response(@message)
+        # Bot auto-response disabled - should only be in dedicated bot interface
+        # bot_response = check_for_bot_response(@message)
 
         format.html { redirect_to @conversation, notice: "Message was successfully sent." }
         format.json do
@@ -93,19 +93,19 @@ class MessagesController < ApplicationController
             }
           }
 
-          # Include bot response if generated
-          if bot_response
-            response_data[:bot_response] = {
-              id: bot_response.id,
-              content: bot_response.content,
-              sender: {
-                id: bot_response.sender.id,
-                name: bot_response.sender.name,
-                role: bot_response.sender.role
-              },
-              created_at: bot_response.created_at
-            }
-          end
+          # Bot response logic removed - no longer auto-responding in conversations
+          # if bot_response
+          #   response_data[:bot_response] = {
+          #     id: bot_response.id,
+          #     content: bot_response.content,
+          #     sender: {
+          #       id: bot_response.sender.id,
+          #       name: bot_response.sender.name,
+          #       role: bot_response.sender.role
+          #     },
+          #     created_at: bot_response.created_at
+          #   }
+          # end
 
           render json: response_data, status: :created
         end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -28,7 +28,7 @@ class Message < ApplicationRecord
   end
 
   def create_notification
-    Notification.create_message_notification(recipient, sender, content)
+    Notification.create_message_notification(recipient, sender, content, conversation)
   rescue => e
     Rails.logger.error "Failed to create message notification: #{e.message}"
   end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -50,13 +50,13 @@ class Notification < ApplicationRecord
       )
     end
 
-    def create_message_notification(recipient, sender, message_content)
+    def create_message_notification(recipient, sender, message_content, conversation)
       create!(
         user: recipient,
         title: "New Message",
         message: "#{sender.name || sender.email}: #{message_content.truncate(50)}",
         notification_type: "message",
-        url: "/messages"
+        url: "/conversations/#{conversation.id}"
       )
     end
 

--- a/app/views/lease_agreements/index.html.erb
+++ b/app/views/lease_agreements/index.html.erb
@@ -204,10 +204,9 @@
                   <% end %>
                   
                   <% if current_user.landlord? && lease.status == 'signed' %>
-                    <%= link_to activate_lease_agreement_path(lease), 
-                                method: :post,
+                    <%= link_to activate_lease_agreement_path(lease),
                                 class: "inline-flex items-center px-3 py-2 bg-green-600 hover:bg-green-700 text-white rounded-xl font-medium transition-all duration-200",
-                                data: { confirm: "Activate this lease?" } do %>
+                                data: { turbo_method: :post, confirm: "Activate this lease?" } do %>
                       Activate
                     <% end %>
                   <% end %>
@@ -215,17 +214,15 @@
                   <!-- Sign buttons for pending signatures -->
                   <% if lease.status == 'pending_signatures' %>
                     <% if current_user == lease.tenant && lease.tenant_signed_at.blank? %>
-                      <%= link_to sign_tenant_lease_agreement_path(lease), 
-                                  method: :post,
+                      <%= link_to sign_tenant_lease_agreement_path(lease),
                                   class: "inline-flex items-center px-3 py-2 bg-green-600 hover:bg-green-700 text-white rounded-xl font-medium transition-all duration-200",
-                                  data: { confirm: "Sign this lease?" } do %>
+                                  data: { turbo_method: :post, confirm: "Sign this lease?" } do %>
                         Sign
                       <% end %>
                     <% elsif current_user == lease.landlord && lease.landlord_signed_at.blank? %>
-                      <%= link_to sign_landlord_lease_agreement_path(lease), 
-                                  method: :post,
+                      <%= link_to sign_landlord_lease_agreement_path(lease),
                                   class: "inline-flex items-center px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-medium transition-all duration-200",
-                                  data: { confirm: "Sign this lease?" } do %>
+                                  data: { turbo_method: :post, confirm: "Sign this lease?" } do %>
                         Sign
                       <% end %>
                     <% end %>

--- a/app/views/lease_agreements/show.html.erb
+++ b/app/views/lease_agreements/show.html.erb
@@ -239,10 +239,9 @@
           <% end %>
           
           <% if @lease_agreement.status == 'signed' %>
-            <%= link_to activate_lease_agreement_path(@lease_agreement), 
-                        method: :post,
+            <%= link_to activate_lease_agreement_path(@lease_agreement),
                         class: "inline-flex items-center px-6 py-3 bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-700 hover:to-emerald-700 text-white rounded-2xl font-bold transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5",
-                        data: { confirm: "Activate this lease agreement?" } do %>
+                        data: { turbo_method: :post, confirm: "Activate this lease agreement?" } do %>
               <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"></path>
               </svg>
@@ -254,10 +253,9 @@
         <!-- Signing Actions -->
         <% if @can_sign %>
           <% if current_user == @lease_agreement.tenant && @lease_agreement.tenant_signed_at.blank? %>
-            <%= link_to sign_tenant_lease_agreement_path(@lease_agreement), 
-                        method: :post,
+            <%= link_to sign_tenant_lease_agreement_path(@lease_agreement),
                         class: "inline-flex items-center px-6 py-3 bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-700 hover:to-emerald-700 text-white rounded-2xl font-bold transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5",
-                        data: { confirm: "Sign this lease agreement?" } do %>
+                        data: { turbo_method: :post, confirm: "Sign this lease agreement?" } do %>
               <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"></path>
               </svg>
@@ -266,10 +264,9 @@
           <% end %>
           
           <% if current_user == @lease_agreement.landlord && @lease_agreement.landlord_signed_at.blank? %>
-            <%= link_to sign_landlord_lease_agreement_path(@lease_agreement), 
-                        method: :post,
+            <%= link_to sign_landlord_lease_agreement_path(@lease_agreement),
                         class: "inline-flex items-center px-6 py-3 bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white rounded-2xl font-bold transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5",
-                        data: { confirm: "Sign this lease agreement?" } do %>
+                        data: { turbo_method: :post, confirm: "Sign this lease agreement?" } do %>
               <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"></path>
               </svg>


### PR DESCRIPTION
## Summary
This PR fixes critical routing errors in the messaging notification system and updates lease agreement buttons to use Rails 7+ syntax.

## Changes Made

### 1. Message Notification Routing Fix
- **Problem**: Clicking message notifications resulted in `No route matches [GET] '/messages'` error
- **Root Cause**: Notifications were using `/messages` URL which doesn't exist in routes
- **Solution**: 
  - Updated `Notification.create_message_notification` to accept `conversation` parameter
  - Changed notification URL from `/messages` to `/conversations/{id}`
  - Updated `Message` model to pass conversation to notification creation

### 2. Bot Auto-Response Removal
- **Problem**: Ofie Assistant bot was auto-responding in tenant-landlord conversations
- **Solution**: Disabled bot auto-response in `MessagesController`
- **Rationale**: Bot should only respond in dedicated bot interface, not in regular user conversations

### 3. Lease Agreement Button Routing Fix
- **Problem**: Signing and activation buttons resulted in `No route matches [GET]` errors
- **Root Cause**: Rails 7+ deprecated `method: :post` in `link_to` helpers
- **Solution**: Updated all 6 buttons to use `data: { turbo_method: :post }`
  - 3 buttons in `app/views/lease_agreements/show.html.erb`
  - 3 buttons in `app/views/lease_agreements/index.html.erb`

## Files Changed (5 files, 30 insertions, 36 deletions)
- `app/models/notification.rb` - Updated message notification URL generation
- `app/models/message.rb` - Pass conversation to notification creation
- `app/controllers/messages_controller.rb` - Disabled bot auto-response
- `app/views/lease_agreements/show.html.erb` - Fixed button routing syntax
- `app/views/lease_agreements/index.html.erb` - Fixed button routing syntax

## Database Migration
- ✅ Updated 6 existing notifications to use correct conversation URLs
- ✅ Confirmed no notifications remain with `/messages` URL

## Testing
- ✅ Message notifications now correctly link to conversations
- ✅ Lease agreement buttons use proper Turbo syntax
- ✅ No routing errors when clicking notifications or signing leases

## Resolves
- No route matches [GET] '/messages'
- No route matches [GET] '/lease_agreements/{id}/sign_tenant'
- Couldn't find Conversation with 'id'=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>